### PR TITLE
feat: Save videos to a list for watching them later

### DIFF
--- a/common/src/main/kotlin/de/justjanne/voctotv/common/viewmodel/WatchLaterViewModel.kt
+++ b/common/src/main/kotlin/de/justjanne/voctotv/common/viewmodel/WatchLaterViewModel.kt
@@ -1,0 +1,37 @@
+package de.justjanne.voctotv.common.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import de.justjanne.voctotv.common.watchlater.WatchLaterItem
+import de.justjanne.voctotv.common.watchlater.WatchLaterRepository
+import de.justjanne.voctotv.voctoweb.model.LectureModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class WatchLaterViewModel
+    @Inject
+    constructor(
+        private val repository: WatchLaterRepository,
+    ) : ViewModel() {
+        val items: StateFlow<List<WatchLaterItem>> =
+            repository.items
+                .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+        val itemIds: StateFlow<Set<String>> =
+            items
+                .map { it.map { item -> item.guid }.toSet() }
+                .stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
+
+        fun remove(guid: String) {
+            repository.remove(guid)
+        }
+
+        fun toggle(lecture: LectureModel) {
+            repository.toggle(lecture)
+        }
+    }

--- a/common/src/main/kotlin/de/justjanne/voctotv/common/watchlater/WatchLaterItem.kt
+++ b/common/src/main/kotlin/de/justjanne/voctotv/common/watchlater/WatchLaterItem.kt
@@ -1,0 +1,56 @@
+package de.justjanne.voctotv.common.watchlater
+
+import de.justjanne.voctotv.voctoweb.model.LectureModel
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WatchLaterItem(
+    val guid: String,
+    val title: String,
+    val persons: List<String>,
+    val duration: Long,
+    val thumbUrl: String,
+    val conferenceTitle: String,
+) {
+    companion object {
+        fun fromLecture(lecture: LectureModel): WatchLaterItem =
+            WatchLaterItem(
+                guid = lecture.guid,
+                title = lecture.title,
+                persons = lecture.persons,
+                duration = lecture.duration,
+                thumbUrl = lecture.thumbUrl,
+                conferenceTitle = lecture.conferenceTitle,
+            )
+    }
+}
+
+fun WatchLaterItem.toLectureModel(): LectureModel =
+    LectureModel(
+        guid = guid,
+        title = title,
+        subtitle = null,
+        slug = guid,
+        link = null,
+        description = null,
+        originalLanguage = "",
+        persons = persons,
+        tags = emptyList(),
+        viewCount = 0,
+        promoted = false,
+        date = null,
+        releaseDate = null,
+        updatedAt = null,
+        length = duration,
+        duration = duration,
+        thumbUrl = thumbUrl,
+        posterUrl = thumbUrl,
+        timelineUrl = "",
+        thumbnailsUrl = "",
+        frontendLink = "",
+        url = "",
+        conferenceTitle = conferenceTitle,
+        conferenceUrl = "",
+        related = emptyList(),
+        resources = null,
+    )

--- a/common/src/main/kotlin/de/justjanne/voctotv/common/watchlater/WatchLaterRepository.kt
+++ b/common/src/main/kotlin/de/justjanne/voctotv/common/watchlater/WatchLaterRepository.kt
@@ -1,0 +1,60 @@
+package de.justjanne.voctotv.common.watchlater
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import de.justjanne.voctotv.voctoweb.model.LectureModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WatchLaterRepository
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) {
+        private val json = Json { ignoreUnknownKeys = true }
+        private val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+        private val _items = MutableStateFlow(load())
+        val items: StateFlow<List<WatchLaterItem>> = _items.asStateFlow()
+
+        fun contains(guid: String): Boolean = _items.value.any { it.guid == guid }
+
+        fun toggle(lecture: LectureModel) {
+            val item = WatchLaterItem.fromLecture(lecture)
+            val next =
+                if (contains(lecture.guid)) {
+                    _items.value.filterNot { it.guid == lecture.guid }
+                } else {
+                    listOf(item) + _items.value.filterNot { it.guid == lecture.guid }
+                }
+            save(next)
+        }
+
+        fun remove(guid: String) {
+            save(_items.value.filterNot { it.guid == guid })
+        }
+
+        private fun save(items: List<WatchLaterItem>) {
+            _items.value = items
+            preferences.edit().putString(KEY_ITEMS, json.encodeToString(items)).apply()
+        }
+
+        private fun load(): List<WatchLaterItem> {
+            val encoded = preferences.getString(KEY_ITEMS, null) ?: return emptyList()
+            return runCatching {
+                json.decodeFromString<List<WatchLaterItem>>(encoded)
+            }.getOrNull() ?: emptyList()
+        }
+
+        companion object {
+            private const val PREFS_NAME = "watch_later"
+            private const val KEY_ITEMS = "items"
+        }
+    }

--- a/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/Routes.kt
+++ b/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/Routes.kt
@@ -28,6 +28,9 @@ object Routes {
     data object Search : NavKey
 
     @Serializable
+    data object WatchLater : NavKey
+
+    @Serializable
     data class PlayerVod(
         val id: String,
     ) : NavKey

--- a/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/AppRouter.kt
+++ b/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/AppRouter.kt
@@ -25,12 +25,14 @@ import de.justjanne.voctotv.common.viewmodel.LiveConferenceViewModel
 import de.justjanne.voctotv.common.viewmodel.PlayerLiveViewModel
 import de.justjanne.voctotv.common.viewmodel.PlayerVodViewModel
 import de.justjanne.voctotv.common.viewmodel.SearchViewModel
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
 import de.justjanne.voctotv.mobile.Routes
 import de.justjanne.voctotv.mobile.route.conference.ConferenceRoute
 import de.justjanne.voctotv.mobile.route.home.HomeRoute
 import de.justjanne.voctotv.mobile.route.liveconference.LiveConferenceRoute
 import de.justjanne.voctotv.mobile.route.player.PlayerRoute
 import de.justjanne.voctotv.mobile.route.search.SearchRoute
+import de.justjanne.voctotv.mobile.route.watchlater.WatchLaterRoute
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,6 +83,10 @@ fun AppRouter(startRoute: NavKey? = null) {
                 entry<Routes.Search> {
                     val viewModel = hiltViewModel<SearchViewModel>()
                     SearchRoute(viewModel, navigate, back)
+                }
+                entry<Routes.WatchLater> {
+                    val viewModel = hiltViewModel<WatchLaterViewModel>()
+                    WatchLaterRoute(viewModel, navigate, back)
                 }
                 entry<Routes.PlayerVod> { key ->
                     val viewModel =

--- a/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/conference/ConferenceRoute.kt
+++ b/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/conference/ConferenceRoute.kt
@@ -36,8 +36,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.NavKey
 import de.justjanne.voctotv.common.viewmodel.ConferenceViewModel
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
 import de.justjanne.voctotv.mobile.R
 import de.justjanne.voctotv.mobile.Routes
 import de.justjanne.voctotv.mobile.ui.LectureItem
@@ -49,10 +51,12 @@ fun ConferenceRoute(
     navigate: (NavKey) -> Unit,
     back: () -> Unit,
 ) {
+    val watchLaterViewModel = hiltViewModel<WatchLaterViewModel>()
     val conference = viewModel.conference.collectAsState().value
     val currentFilter = viewModel.currentFilter.collectAsState().value
     val filterOptions = viewModel.filterOptions.collectAsState().value
     val filteredItems = viewModel.filteredItems.collectAsState().value
+    val watchLaterIds = watchLaterViewModel.itemIds.collectAsState().value
 
     Scaffold(
         topBar = {
@@ -125,9 +129,11 @@ fun ConferenceRoute(
                     items(filteredItems, key = { it.guid }) { item ->
                         LectureItem(
                             item = item,
+                            isSaved = watchLaterIds.contains(item.guid),
                             onClick = {
                                 navigate(Routes.PlayerVod(item.guid))
                             },
+                            onLongClick = { watchLaterViewModel.toggle(item) },
                         )
                     }
                 }

--- a/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/home/HeroCarouselLecture.kt
+++ b/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/home/HeroCarouselLecture.kt
@@ -1,42 +1,74 @@
 package de.justjanne.voctotv.mobile.route.home
 
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastJoinToString
 import androidx.navigation3.runtime.NavKey
 import coil3.compose.rememberAsyncImagePainter
 import de.justjanne.voctotv.common.viewmodel.FeaturedItem
+import de.justjanne.voctotv.mobile.R
 import de.justjanne.voctotv.mobile.Routes
 import de.justjanne.voctotv.mobile.ui.WatchNowButton
 import de.justjanne.voctotv.mobile.ui.carousel.HeroCarouselContent
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HeroCarouselLecture(
     item: FeaturedItem.Lecture,
     navigate: (NavKey) -> Unit,
+    isSaved: Boolean,
+    onLongClick: () -> Unit,
 ) {
     val painter = rememberAsyncImagePainter(item.lecture.posterUrl)
 
-    HeroCarouselContent(
-        background = painter,
-        title = {
-            Text(
-                item.lecture.title,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 2,
+    Box(
+        modifier =
+            Modifier.combinedClickable(
+                onClick = { navigate(Routes.PlayerVod(item.lecture.guid)) },
+                onLongClick = onLongClick,
+            ),
+    ) {
+        HeroCarouselContent(
+            background = painter,
+            title = {
+                Text(
+                    item.lecture.title,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 2,
+                )
+            },
+            description = {
+                Text(
+                    item.lecture.persons.fastJoinToString(" · "),
+                    maxLines = 1,
+                )
+            },
+            action = {
+                WatchNowButton(onClick = {
+                    navigate(Routes.PlayerVod(item.lecture.guid))
+                })
+            },
+        )
+        if (isSaved) {
+            Icon(
+                painter = painterResource(R.drawable.ic_star),
+                contentDescription = stringResource(R.string.action_watch_later),
+                tint = Color(0xFFFFD54F),
+                modifier = Modifier.align(Alignment.TopEnd).padding(12.dp).size(20.dp),
             )
-        },
-        description = {
-            Text(
-                item.lecture.persons.fastJoinToString(" · "),
-                maxLines = 1,
-            )
-        },
-        action = {
-            WatchNowButton(onClick = {
-                navigate(Routes.PlayerVod(item.lecture.guid))
-            })
-        },
-    )
+        }
+    }
 }

--- a/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/home/HomeRoute.kt
+++ b/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/home/HomeRoute.kt
@@ -36,10 +36,12 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.NavKey
 import de.justjanne.voctotv.common.viewmodel.ConferenceKind
 import de.justjanne.voctotv.common.viewmodel.FeaturedItem
 import de.justjanne.voctotv.common.viewmodel.HomeViewModel
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
 import de.justjanne.voctotv.common.viewmodel.kind
 import de.justjanne.voctotv.mobile.R
 import de.justjanne.voctotv.mobile.Routes
@@ -51,9 +53,11 @@ fun HomeRoute(
     viewModel: HomeViewModel,
     navigate: (NavKey) -> Unit,
 ) {
+    val watchLaterViewModel = hiltViewModel<WatchLaterViewModel>()
     val currentFilter = viewModel.currentFilter.collectAsState().value
     val filteredItems = viewModel.filteredItems.collectAsState().value
     val featuredItems = viewModel.featuredItems.collectAsState().value
+    val watchLaterIds = watchLaterViewModel.itemIds.collectAsState().value
 
     Scaffold(
         topBar = {
@@ -72,6 +76,14 @@ fun HomeRoute(
                         Icon(
                             painterResource(R.drawable.ic_search),
                             contentDescription = stringResource(R.string.action_search),
+                        )
+                    }
+                    IconButton(
+                        onClick = { navigate(Routes.WatchLater) },
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.ic_star),
+                            contentDescription = stringResource(R.string.action_watch_later),
                         )
                     }
                 },
@@ -98,7 +110,13 @@ fun HomeRoute(
                 item("featured") {
                     HeroCarousel(count = featuredItems.size) { index ->
                         when (val item = featuredItems[index]) {
-                            is FeaturedItem.Lecture -> HeroCarouselLecture(item, navigate)
+                            is FeaturedItem.Lecture ->
+                                HeroCarouselLecture(
+                                    item = item,
+                                    navigate = navigate,
+                                    isSaved = watchLaterIds.contains(item.lecture.guid),
+                                    onLongClick = { watchLaterViewModel.toggle(item.lecture) },
+                                )
                             is FeaturedItem.Stream -> HeroCarouselStream(item, navigate)
                         }
                     }

--- a/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/search/SearchRoute.kt
+++ b/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/search/SearchRoute.kt
@@ -19,10 +19,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.NavKey
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import de.justjanne.voctotv.common.viewmodel.SearchViewModel
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
 import de.justjanne.voctotv.mobile.Routes
 import de.justjanne.voctotv.mobile.ui.LectureItem
 
@@ -33,8 +35,10 @@ fun SearchRoute(
     navigate: (NavKey) -> Unit,
     back: () -> Unit,
 ) {
+    val watchLaterViewModel = hiltViewModel<WatchLaterViewModel>()
     val query by viewModel.query.collectAsState()
     val results = viewModel.results.collectAsLazyPagingItems()
+    val watchLaterIds = watchLaterViewModel.itemIds.collectAsState().value
 
     val focusRequester = remember { FocusRequester() }
 
@@ -70,7 +74,9 @@ fun SearchRoute(
                     if (item != null) {
                         LectureItem(
                             item = item,
+                            isSaved = watchLaterIds.contains(item.guid),
                             onClick = { navigate(Routes.PlayerVod(item.guid)) },
+                            onLongClick = { watchLaterViewModel.toggle(item) },
                         )
                     }
                 }

--- a/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/watchlater/WatchLaterRoute.kt
+++ b/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/route/watchlater/WatchLaterRoute.kt
@@ -1,0 +1,70 @@
+package de.justjanne.voctotv.mobile.route.watchlater
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation3.runtime.NavKey
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
+import de.justjanne.voctotv.common.watchlater.toLectureModel
+import de.justjanne.voctotv.mobile.R
+import de.justjanne.voctotv.mobile.Routes
+import de.justjanne.voctotv.mobile.ui.LectureItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WatchLaterRoute(
+    viewModel: WatchLaterViewModel,
+    navigate: (NavKey) -> Unit,
+    back: () -> Unit,
+) {
+    val items = viewModel.items.collectAsState().value
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.action_watch_later)) },
+                navigationIcon = {
+                    IconButton(onClick = back) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_arrow_back),
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        if (items.isEmpty()) {
+            Box(Modifier.fillMaxSize()) {
+                Text(
+                    text = stringResource(R.string.watch_later_empty),
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            }
+        } else {
+            LazyColumn(contentPadding = contentPadding, modifier = Modifier.fillMaxSize()) {
+                items(items, key = { it.guid }) { item ->
+                    LectureItem(
+                        item = item.toLectureModel(),
+                        isSaved = true,
+                        onClick = { navigate(Routes.PlayerVod(item.guid)) },
+                        onLongClick = { viewModel.remove(item.guid) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/ui/LectureItem.kt
+++ b/mobile/src/main/kotlin/de/justjanne/voctotv/mobile/ui/LectureItem.kt
@@ -8,7 +8,8 @@
 package de.justjanne.voctotv.mobile.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,7 +18,9 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -25,22 +28,28 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import de.justjanne.voctotv.common.util.formatTime
+import de.justjanne.voctotv.mobile.R
 import de.justjanne.voctotv.voctoweb.model.LectureModel
 
 @Composable
 fun LectureItem(
     item: LectureModel,
     onClick: () -> Unit = {},
+    onLongClick: () -> Unit = {},
+    isSaved: Boolean = false,
 ) {
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .combinedClickable(onClick = onClick, onLongClick = onLongClick)
                 .padding(16.dp, 4.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
@@ -71,6 +80,14 @@ fun LectureItem(
                         color = MaterialTheme.colorScheme.onSurface,
                     ),
             )
+            if (isSaved) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_star),
+                    contentDescription = stringResource(R.string.action_watch_later),
+                    tint = Color(0xFFFFD54F),
+                    modifier = Modifier.align(Alignment.TopEnd).padding(6.dp).size(18.dp),
+                )
+            }
         }
         Column(Modifier.padding(vertical = 12.dp)) {
             Text(

--- a/mobile/src/main/res/drawable/ic_star.xml
+++ b/mobile/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,17.27L18.18,21 16.54,13.97 22,9.24 14.81,8.63 12,2 9.19,8.63 2,9.24 7.46,13.97 5.82,21z"/>
+</vector>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -22,6 +22,8 @@
   <string name="action_play">Play</string>
   <string name="action_restart">Play Again</string>
   <string name="action_search">Search</string>
+  <string name="action_watch_later">Watch Later</string>
+  <string name="action_toggle_watch_later">Toggle Watch Later</string>
   <string name="action_fullscreen_enter">Enter Fullscreen</string>
   <string name="action_fullscreen_exit">Exit Fullscreen</string>
 
@@ -38,6 +40,7 @@
 
   <string name="search_results_placeholder">Enter a search term to start searching.</string>
   <string name="search_results_notfound">No results found for "%1$s"</string>
+  <string name="watch_later_empty">No saved videos yet. Long press a video to add it.</string>
 
   <string name="schedule_break">Break</string>
   <string name="schedule_current">Now playing:</string>

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/Routes.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/Routes.kt
@@ -25,6 +25,9 @@ object Routes {
     ) : NavKey
 
     @Serializable
+    data object WatchLater : NavKey
+
+    @Serializable
     data class PlayerVod(
         val id: String,
     ) : NavKey

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/AppRouter.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/AppRouter.kt
@@ -21,11 +21,13 @@ import de.justjanne.voctotv.common.viewmodel.HomeViewModel
 import de.justjanne.voctotv.common.viewmodel.LiveConferenceViewModel
 import de.justjanne.voctotv.common.viewmodel.PlayerLiveViewModel
 import de.justjanne.voctotv.common.viewmodel.PlayerVodViewModel
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
 import de.justjanne.voctotv.tv.Routes
 import de.justjanne.voctotv.tv.route.conference.ConferenceRoute
 import de.justjanne.voctotv.tv.route.home.HomeRoute
 import de.justjanne.voctotv.tv.route.liveconference.LiveConferenceRoute
 import de.justjanne.voctotv.tv.route.player.PlayerRoute
+import de.justjanne.voctotv.tv.route.watchlater.WatchLaterRoute
 
 @Composable
 fun AppRouter() {
@@ -64,6 +66,10 @@ fun AppRouter() {
                         }
 
                     LiveConferenceRoute(viewModel, navigate)
+                }
+                entry<Routes.WatchLater> {
+                    val viewModel = hiltViewModel<WatchLaterViewModel>()
+                    WatchLaterRoute(viewModel, navigate)
                 }
                 entry<Routes.PlayerVod> { key ->
                     val viewModel =

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/conference/ConferenceRoute.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/conference/ConferenceRoute.kt
@@ -28,10 +28,12 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.NavKey
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import de.justjanne.voctotv.common.viewmodel.ConferenceViewModel
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
 import de.justjanne.voctotv.tv.R
 import de.justjanne.voctotv.tv.ui.LectureCard
 import de.justjanne.voctotv.tv.ui.theme.GridGutter
@@ -43,10 +45,12 @@ fun ConferenceRoute(
     viewModel: ConferenceViewModel,
     navigate: (NavKey) -> Unit,
 ) {
+    val watchLaterViewModel = hiltViewModel<WatchLaterViewModel>()
     val conference by viewModel.conference.collectAsState()
     val popular by viewModel.popular.collectAsState()
     val recent by viewModel.recent.collectAsState()
     val itemsByTrack by viewModel.itemsByTrack.collectAsState()
+    val watchLaterIds by watchLaterViewModel.itemIds.collectAsState()
 
     LazyColumn(
         verticalArrangement = Arrangement.Top,
@@ -91,6 +95,8 @@ fun ConferenceRoute(
                         lecture,
                         navigate,
                         if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
+                        onLongClick = { watchLaterViewModel.toggle(lecture) },
+                        isSaved = watchLaterIds.contains(lecture.guid),
                     )
                 }
             }
@@ -113,6 +119,8 @@ fun ConferenceRoute(
                         lecture,
                         navigate,
                         if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
+                        onLongClick = { watchLaterViewModel.toggle(lecture) },
+                        isSaved = watchLaterIds.contains(lecture.guid),
                     )
                 }
             }
@@ -135,6 +143,8 @@ fun ConferenceRoute(
                         lecture,
                         navigate,
                         if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
+                        onLongClick = { watchLaterViewModel.toggle(lecture) },
+                        isSaved = watchLaterIds.contains(lecture.guid),
                     )
                 }
             }

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/home/FeaturedCarousel.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/home/FeaturedCarousel.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavKey
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import de.justjanne.voctotv.common.viewmodel.FeaturedItem
+import de.justjanne.voctotv.voctoweb.model.LectureModel
 import de.justjanne.voctotv.tv.ui.carousel.HeroCarousel
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -19,11 +20,19 @@ import de.justjanne.voctotv.tv.ui.carousel.HeroCarousel
 fun FeaturedCarousel(
     items: List<FeaturedItem>,
     navigate: (NavKey) -> Unit,
+    isLectureSaved: (String) -> Boolean,
+    onLectureLongClick: (LectureModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     HeroCarousel(items.size, modifier = modifier) { index ->
         when (val item = items[index]) {
-            is FeaturedItem.Lecture -> HeroCarouselLecture(item, navigate)
+            is FeaturedItem.Lecture ->
+                HeroCarouselLecture(
+                    item = item,
+                    navigate = navigate,
+                    isSaved = isLectureSaved(item.lecture.guid),
+                    onLongClick = { onLectureLongClick(item.lecture) },
+                )
             is FeaturedItem.Stream -> HeroCarouselStream(item, navigate)
         }
     }

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/home/HeroCarouselLecture.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/home/HeroCarouselLecture.kt
@@ -1,14 +1,25 @@
 package de.justjanne.voctotv.tv.route.home
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.util.fastJoinToString
+import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.Text
 import coil3.compose.rememberAsyncImagePainter
 import de.justjanne.voctotv.common.viewmodel.FeaturedItem
+import de.justjanne.voctotv.tv.R
 import de.justjanne.voctotv.tv.Routes
 import de.justjanne.voctotv.tv.ui.WatchNowButton
 import de.justjanne.voctotv.tv.ui.carousel.HeroCarouselContent
@@ -18,9 +29,12 @@ import de.justjanne.voctotv.tv.ui.carousel.HeroCarouselDefaults
 fun HeroCarouselLecture(
     item: FeaturedItem.Lecture,
     navigate: (NavKey) -> Unit,
+    isSaved: Boolean,
+    onLongClick: () -> Unit,
 ) {
     Card(
         onClick = { navigate(Routes.PlayerVod(item.lecture.guid)) },
+        onLongClick = onLongClick,
         colors =
             CardDefaults.colors(
                 containerColor = HeroCarouselDefaults.BackgroundColor,
@@ -29,38 +43,48 @@ fun HeroCarouselLecture(
             ),
     ) {
         val background = rememberAsyncImagePainter(item.lecture.posterUrl)
-        HeroCarouselContent(
-            background = background,
-            label = {
-                Text(
-                    item.lecture.conferenceTitle,
-                    maxLines = 1,
-                )
-            },
-            title = {
-                Text(
-                    item.lecture.title,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 2,
-                )
-            },
-            byline = {
-                Text(item.lecture.persons.fastJoinToString(" · "))
-            },
-            description = {
-                item.lecture.description?.let {
+        Box {
+            HeroCarouselContent(
+                background = background,
+                label = {
                     Text(
-                        it.replace(Regex("\n\n+"), "\n"),
-                        maxLines = 3,
-                        overflow = TextOverflow.Ellipsis,
+                        item.lecture.conferenceTitle,
+                        maxLines = 1,
                     )
-                }
-            },
-            action = {
-                WatchNowButton(onClick = {
-                    navigate(Routes.PlayerVod(item.lecture.guid))
-                })
-            },
-        )
+                },
+                title = {
+                    Text(
+                        item.lecture.title,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 2,
+                    )
+                },
+                byline = {
+                    Text(item.lecture.persons.fastJoinToString(" · "))
+                },
+                description = {
+                    item.lecture.description?.let {
+                        Text(
+                            it.replace(Regex("\n\n+"), "\n"),
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                },
+                action = {
+                    WatchNowButton(onClick = {
+                        navigate(Routes.PlayerVod(item.lecture.guid))
+                    })
+                },
+            )
+            if (isSaved) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_star),
+                    contentDescription = stringResource(R.string.action_watch_later),
+                    tint = Color(0xFFFFD54F),
+                    modifier = Modifier.align(Alignment.TopEnd).padding(12.dp).size(24.dp),
+                )
+            }
+        }
     }
 }

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/home/HomeRoute.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/home/HomeRoute.kt
@@ -32,12 +32,17 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.NavKey
 import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.Icon
+import androidx.tv.material3.IconButton
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.Text
 import de.justjanne.voctotv.common.viewmodel.ConferenceKind
 import de.justjanne.voctotv.common.viewmodel.HomeViewModel
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
+import de.justjanne.voctotv.tv.Routes
 import de.justjanne.voctotv.tv.R
 import de.justjanne.voctotv.tv.ui.LectureCard
 import de.justjanne.voctotv.tv.ui.theme.GridGutter
@@ -49,10 +54,12 @@ fun HomeRoute(
     viewModel: HomeViewModel,
     navigate: (NavKey) -> Unit,
 ) {
+    val watchLaterViewModel = hiltViewModel<WatchLaterViewModel>()
     val conferences by viewModel.conferences.collectAsState()
     val recent by viewModel.recentResult.collectAsState()
     val popular by viewModel.popularResult.collectAsState()
     val featuredItems by viewModel.featuredItems.collectAsState()
+    val watchLaterIds by watchLaterViewModel.itemIds.collectAsState()
 
     val focusRequester = remember { FocusRequester() }
 
@@ -79,12 +86,26 @@ fun HomeRoute(
                     modifier = Modifier.height(32.dp),
                     colorFilter = ColorFilter.tint(LocalContentColor.current),
                 )
+                IconButton(
+                    onClick = { navigate(Routes.WatchLater) },
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_star),
+                        contentDescription = stringResource(R.string.action_watch_later),
+                    )
+                }
             }
         }
 
         if (featuredItems.isNotEmpty()) {
             item("featured") {
-                FeaturedCarousel(featuredItems, navigate, Modifier.focusRequester(focusRequester))
+                FeaturedCarousel(
+                    items = featuredItems,
+                    navigate = navigate,
+                    isLectureSaved = { guid -> watchLaterIds.contains(guid) },
+                    onLectureLongClick = { lecture -> watchLaterViewModel.toggle(lecture) },
+                    modifier = Modifier.focusRequester(focusRequester),
+                )
             }
         }
 
@@ -106,6 +127,8 @@ fun HomeRoute(
                             lecture,
                             navigate,
                             if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
+                            onLongClick = { watchLaterViewModel.toggle(lecture) },
+                            isSaved = watchLaterIds.contains(lecture.guid),
                         )
                     }
                 }
@@ -130,6 +153,8 @@ fun HomeRoute(
                             lecture,
                             navigate,
                             if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
+                            onLongClick = { watchLaterViewModel.toggle(lecture) },
+                            isSaved = watchLaterIds.contains(lecture.guid),
                         )
                     }
                 }

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/watchlater/WatchLaterRoute.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/route/watchlater/WatchLaterRoute.kt
@@ -1,0 +1,120 @@
+package de.justjanne.voctotv.tv.route.watchlater
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavKey
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import de.justjanne.voctotv.common.watchlater.toLectureModel
+import de.justjanne.voctotv.common.viewmodel.WatchLaterViewModel
+import de.justjanne.voctotv.tv.R
+import de.justjanne.voctotv.tv.ui.LectureCard
+import de.justjanne.voctotv.tv.ui.theme.GridGutter
+import de.justjanne.voctotv.tv.ui.theme.GridPadding
+import de.justjanne.voctotv.tv.ui.theme.textShadow
+
+@Composable
+fun WatchLaterRoute(
+    viewModel: WatchLaterViewModel,
+    navigate: (NavKey) -> Unit,
+) {
+    val items by viewModel.items.collectAsState()
+    val consumeNextCenterKeyUp = remember { mutableStateOf(false) }
+
+    LazyColumn(
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.Start,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        item("header") {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(start = GridGutter, end = GridGutter, top = 32.dp, bottom = GridPadding),
+            ) {
+                Text(
+                    text = stringResource(R.string.action_watch_later),
+                    style =
+                        MaterialTheme.typography.titleLarge.copy(
+                            shadow = MaterialTheme.colorScheme.textShadow,
+                        ),
+                    maxLines = 2,
+                )
+            }
+        }
+
+        if (items.isEmpty()) {
+            item("empty") {
+                Box(Modifier.fillMaxSize()) {
+                    Text(
+                        text = stringResource(R.string.watch_later_empty),
+                        modifier = Modifier.align(Alignment.Center).padding(GridGutter),
+                    )
+                }
+            }
+        } else {
+            item("saved") {
+                val focusRequester = remember("watch-later") { FocusRequester() }
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(GridPadding),
+                    contentPadding = PaddingValues(vertical = GridPadding, horizontal = GridGutter),
+                    modifier =
+                        Modifier
+                            .focusRestorer(focusRequester)
+                            .onPreviewKeyEvent { event ->
+                                val isCenterKey =
+                                    event.key == Key.DirectionCenter ||
+                                        event.key == Key.Enter ||
+                                        event.key == Key.NumPadEnter
+                                if (consumeNextCenterKeyUp.value && isCenterKey && event.type == KeyEventType.KeyUp) {
+                                    consumeNextCenterKeyUp.value = false
+                                    true
+                                } else {
+                                    false
+                                }
+                            },
+                ) {
+                    itemsIndexed(items, key = { _, lecture -> lecture.guid }) { index, lecture ->
+                        LectureCard(
+                            lecture = lecture.toLectureModel(),
+                            navigate = navigate,
+                            modifier = if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
+                            isSaved = true,
+                            onLongClick = {
+                                consumeNextCenterKeyUp.value = true
+                                viewModel.remove(lecture.guid)
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/ui/CompactCard.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/ui/CompactCard.kt
@@ -7,12 +7,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardBorder
@@ -23,6 +28,7 @@ import androidx.tv.material3.CardScale
 import androidx.tv.material3.CardShape
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.ProvideTextStyle
+import de.justjanne.voctotv.tv.R
 import de.justjanne.voctotv.tv.ui.theme.DescriptionAlpha
 import de.justjanne.voctotv.tv.ui.theme.SubtitleAlpha
 
@@ -36,6 +42,7 @@ internal fun CompactCard(
     subtitle: @Composable () -> Unit = {},
     description: @Composable () -> Unit = {},
     badge: @Composable () -> Unit = {},
+    showWatchLaterStar: Boolean = false,
     shape: CardShape = CardDefaults.shape(),
     colors: CardColors = CardDefaults.compactCardColors(),
     scale: CardScale = CardDefaults.scale(),
@@ -67,6 +74,14 @@ internal fun CompactCard(
                 contentAlignment = Alignment.Companion.Center,
                 content = image,
             )
+            if (showWatchLaterStar) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_star),
+                    contentDescription = stringResource(R.string.action_watch_later),
+                    tint = Color(0xFFFFD54F),
+                    modifier = Modifier.align(Alignment.TopEnd).padding(8.dp).size(20.dp),
+                )
+            }
             Column {
                 ProvideTextStyle(
                     MaterialTheme.typography.titleMedium,

--- a/tv/src/main/kotlin/de/justjanne/voctotv/tv/ui/LectureCard.kt
+++ b/tv/src/main/kotlin/de/justjanne/voctotv/tv/ui/LectureCard.kt
@@ -31,11 +31,15 @@ fun LectureCard(
     lecture: LectureModel,
     navigate: (NavKey) -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
+    isSaved: Boolean = false,
 ) {
     CompactCard(
         onClick = {
             navigate(Routes.PlayerVod(lecture.guid))
         },
+        onLongClick = onLongClick,
+        showWatchLaterStar = isSaved,
         modifier =
             modifier
                 .width(268.dp)

--- a/tv/src/main/res/drawable/ic_star.xml
+++ b/tv/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,17.27L18.18,21 16.54,13.97 22,9.24 14.81,8.63 12,2 9.19,8.63 2,9.24 7.46,13.97 5.82,21z"/>
+</vector>

--- a/tv/src/main/res/values/strings.xml
+++ b/tv/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
 
   <string name="action_watchnow">Watch now</string>
   <string name="action_back">Back</string>
+  <string name="action_watch_later">Watch Later</string>
+  <string name="action_toggle_watch_later">Toggle Watch Later</string>
   <string name="action_pause">Pause</string>
   <string name="action_play">Play</string>
   <string name="action_replay">Play Again</string>
@@ -30,6 +32,7 @@
   <string name="category_popular">Popular</string>
 
   <string name="video_info_views">Views</string>
+  <string name="watch_later_empty">No saved videos yet. Long press a video to add it.</string>
 
   <string name="schedule_break">Break</string>
   <string name="schedule_current">Now playing:</string>


### PR DESCRIPTION
Hey ho, I wanted a feature to save talks, that I want to watch in the future, so I added it. When you long press on a video it gets added to a "watch later" list, which is accessible from the main view. Saved videos also have a marked with a star symbol.

Here are some screenshots:

## TV

| <img width="3840" height="2160" alt="main-screen-tv" src="https://github.com/user-attachments/assets/4bcde951-b065-4632-89aa-7483c5d9b3ca" />  | <img width="3840" height="2160" alt="watch-later-empty-tv" src="https://github.com/user-attachments/assets/d572679a-2bd7-4734-bd8e-3e564b960823" />  | <img width="3840" height="2160" alt="watch-later-tv" src="https://github.com/user-attachments/assets/a1ad283b-529e-4dbd-96e4-751ad6e57442" />  |
|---|---|---|

## Mobile

|  <img width="1008" height="2164" alt="main-screen-mobile" src="https://github.com/user-attachments/assets/f121fc09-c2d1-4f19-b542-0d9f7ed8d296" /> |  <img width="1008" height="2162" alt="watch-later-empty-mobile" src="https://github.com/user-attachments/assets/e2146f1d-473b-4700-975c-13db959250ba" /> |  <img width="1008" height="2169" alt="watch-later-mobile" src="https://github.com/user-attachments/assets/5be4ef66-3104-4d14-a097-c40402fd5af5" /> |
|---|---|---|
